### PR TITLE
bug fixed

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -141,7 +141,7 @@ func (client *Client) PrivateANNQuery(keys [][]uint64) int {
 
 	argsB := &api.ANNQueryArgs{}
 	argsB.SessionID = client.SessionParams.SessionID
-	argsB.SecretShared = allQueriesA
+	argsB.SecretShared = allQueriesB
 
 	resA := &api.ANNQueryResponse{}
 	resB := &api.ANNQueryResponse{}

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -46,6 +46,7 @@ func main() {
 	cli.Experiment.QueryUpBandwidthBytes = make([]int64, 0)
 	cli.Experiment.QueryDownBandwidthBytes = make([]int64, 0)
 
+	hash.Precompute()
 	for i := 0; i < args.ExperimentNumTrials; i++ {
 
 		log.Printf("[Client]: waiting for servers to initialize \n")

--- a/pir/db.go
+++ b/pir/db.go
@@ -137,13 +137,13 @@ func (db *Database) ExpandSharedQuery(query *QueryShare, start, stop int) []fiel
 		indices = db.Keywords[start:stop]
 	} else {
 		indices = make([]uint64, stop-start)
-		for i := 0; i < start-stop; i++ {
+		for i := 0; i < stop-start; i++ {
 			indices[i] = uint64(i)
 		}
 	}
 
 	bitsRaw := pf.BatchEval(query.DPFKey, indices)
-	for i := 0; i < start-stop; i++ {
+	for i := 0; i < stop-start; i++ {
 		bits[i] = field.FP(bitsRaw[i])
 	}
 


### PR DESCRIPTION
Calling hash.Precompute() from the client may be not good in terms of efficiency or security? I'm not sure.